### PR TITLE
[FEAT]: 게시글 상세 뷰

### DIFF
--- a/ITZZA/ITZZA.xcodeproj/project.pbxproj
+++ b/ITZZA/ITZZA.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		233B636B27AF9D9D00914F60 /* PostDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233B636A27AF9D9D00914F60 /* PostDetailVC.swift */; };
 		233B636D27AFAE2400914F60 /* PostContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233B636C27AFAE2400914F60 /* PostContentView.swift */; };
 		233B636F27AFAE3100914F60 /* PostContentView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 233B636E27AFAE3100914F60 /* PostContentView.xib */; };
+		2368021127B2965B00A4392B /* PostContentTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2368021027B2965B00A4392B /* PostContentTableViewHeader.swift */; };
+		2368021327B2966800A4392B /* PostContentTableViewHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2368021227B2966800A4392B /* PostContentTableViewHeader.xib */; };
 		236C98DE27B239C200CE1EFD /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236C98DD27B239C200CE1EFD /* UIView+.swift */; };
 		238CEEA027A7DEA0006BE766 /* CommunityNC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238CEE9F27A7DEA0006BE766 /* CommunityNC.swift */; };
 		238CEEA227A7DFCF006BE766 /* NavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238CEEA127A7DFCF006BE766 /* NavigationController+.swift */; };
@@ -67,6 +69,7 @@
 		238EC09C27AA7295001CBB24 /* SearchPostVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238EC09B27AA7295001CBB24 /* SearchPostVC.swift */; };
 		238EC09F27AA88EC001CBB24 /* ImageAddBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238EC09D27AA88EC001CBB24 /* ImageAddBar.swift */; };
 		238EC0A027AA88EC001CBB24 /* ImageAddBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 238EC09E27AA88EC001CBB24 /* ImageAddBar.xib */; };
+		23A56BDA27B3F8BA00959269 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A56BD927B3F8BA00959269 /* UILabel+.swift */; };
 		6208CFDB27A254B900F17603 /* SignIn.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6208CFDA27A254B900F17603 /* SignIn.storyboard */; };
 		6208CFDE27A258F600F17603 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		6208CFE127A2662700F17603 /* SignInVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6208CFE027A2662700F17603 /* SignInVM.swift */; };
@@ -138,6 +141,8 @@
 		233B636A27AF9D9D00914F60 /* PostDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailVC.swift; sourceTree = "<group>"; };
 		233B636C27AFAE2400914F60 /* PostContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostContentView.swift; sourceTree = "<group>"; };
 		233B636E27AFAE3100914F60 /* PostContentView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostContentView.xib; sourceTree = "<group>"; };
+		2368021027B2965B00A4392B /* PostContentTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostContentTableViewHeader.swift; sourceTree = "<group>"; };
+		2368021227B2966800A4392B /* PostContentTableViewHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostContentTableViewHeader.xib; sourceTree = "<group>"; };
 		236C98DD27B239C200CE1EFD /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		238CEE9F27A7DEA0006BE766 /* CommunityNC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityNC.swift; sourceTree = "<group>"; };
 		238CEEA127A7DFCF006BE766 /* NavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationController+.swift"; sourceTree = "<group>"; };
@@ -151,6 +156,7 @@
 		238EC09B27AA7295001CBB24 /* SearchPostVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPostVC.swift; sourceTree = "<group>"; };
 		238EC09D27AA88EC001CBB24 /* ImageAddBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAddBar.swift; sourceTree = "<group>"; };
 		238EC09E27AA88EC001CBB24 /* ImageAddBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImageAddBar.xib; sourceTree = "<group>"; };
+		23A56BD927B3F8BA00959269 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		31D68BDCB09FB35125D965C7 /* Pods-ITZZA.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ITZZA.release.xcconfig"; path = "Target Support Files/Pods-ITZZA/Pods-ITZZA.release.xcconfig"; sourceTree = "<group>"; };
 		557F2FCE2D67BC938F058D88 /* Pods-ITZZA.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ITZZA.debug.xcconfig"; path = "Target Support Files/Pods-ITZZA/Pods-ITZZA.debug.xcconfig"; sourceTree = "<group>"; };
 		6208CFDA27A254B900F17603 /* SignIn.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SignIn.storyboard; sourceTree = "<group>"; };
@@ -529,12 +535,13 @@
 				2305120C27AEE52100CF7FCF /* UIButton+.swift */,
 				232302FE27AFD18000E20078 /* UITextView+.swift */,
 				62BE209F27A8F1A0001F150A /* UIViewController+.swift */,
+				23A56BD927B3F8BA00959269 /* UILabel+.swift */,
+				2323030827B035ED00E20078 /* UITextField+.swift */,
+				236C98DD27B239C200CE1EFD /* UIView+.swift */,
 				232CC08A27A0391F00040131 /* Notification+.swift */,
 				622D07BF27ABF12E00707E47 /* KeychainWrapper+.swift */,
 				238CEEA127A7DFCF006BE766 /* NavigationController+.swift */,
 				627E1A8E27AEAD7D005C1777 /* Array+.swift */,
-				2323030827B035ED00E20078 /* UITextField+.swift */,
-				236C98DD27B239C200CE1EFD /* UIView+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -579,6 +586,8 @@
 				232302FB27AFC13200E20078 /* CommentTVC.xib */,
 				2323030227B02D9200E20078 /* ChatInputView.swift */,
 				2323030327B02D9200E20078 /* ChatInputView.xib */,
+				2368021027B2965B00A4392B /* PostContentTableViewHeader.swift */,
+				2368021227B2966800A4392B /* PostContentTableViewHeader.xib */,
 			);
 			name = Shared;
 			path = ..;
@@ -770,6 +779,7 @@
 				2335241827A98FA0009C654F /* ProfileHeaderView.xib in Resources */,
 				232CC01E27A0317900040131 /* Assets.xcassets in Resources */,
 				238EC0A027AA88EC001CBB24 /* ImageAddBar.xib in Resources */,
+				2368021327B2966800A4392B /* PostContentTableViewHeader.xib in Resources */,
 				232302FD27AFC13200E20078 /* CommentTVC.xib in Resources */,
 				238EC09A27AA7288001CBB24 /* SearchPost.storyboard in Resources */,
 				232CC04C27A032D700040131 /* Community.storyboard in Resources */,
@@ -856,6 +866,8 @@
 				232302FC27AFC13200E20078 /* CommentTVC.swift in Sources */,
 				6208CFE127A2662700F17603 /* SignInVM.swift in Sources */,
 				62C4008727A51ADB002B3F33 /* tmp.swift in Sources */,
+				23A56BDA27B3F8BA00959269 /* UILabel+.swift in Sources */,
+				2368021127B2965B00A4392B /* PostContentTableViewHeader.swift in Sources */,
 				2323030927B035ED00E20078 /* UITextField+.swift in Sources */,
 				232CC07527A0370D00040131 /* TypeOfViewController.swift in Sources */,
 				62E2BDFC27AD41620052DDCE /* UIImage+.swift in Sources */,

--- a/ITZZA/ITZZA/Global/Extension/UILabel+.swift
+++ b/ITZZA/ITZZA/Global/Extension/UILabel+.swift
@@ -1,0 +1,16 @@
+//
+//  UILabel+.swift
+//  ITZZA
+//
+//  Created by 황윤경 on 2022/02/09.
+//
+
+import UIKit
+
+extension UILabel {
+    func setLineBreakMode() {
+        translatesAutoresizingMaskIntoConstraints = false
+        numberOfLines = 0
+        lineBreakMode = .byCharWrapping
+    }
+}

--- a/ITZZA/ITZZA/Global/Struct/Identifiers.swift
+++ b/ITZZA/ITZZA/Global/Struct/Identifiers.swift
@@ -38,6 +38,7 @@ struct Identifiers {
     static let imageAddBar = "ImageAddBar"
     static let postContentView = "PostContentView"
     static let chatInputView = "ChatInputView"
+    static let postContentTableViewHeader = "PostContentTableViewHeader"
     
     //MARK: - TVC
     static let postTVC = "PostTVC"

--- a/ITZZA/ITZZA/Screen/Community/ChatInputView.swift
+++ b/ITZZA/ITZZA/Screen/Community/ChatInputView.swift
@@ -29,6 +29,15 @@ class ChatInputView: UIView {
         guard let view = loadViewFromNib(with: Identifiers.chatInputView) else { return }
         view.backgroundColor = .clear
         self.addSubview(view)
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = [
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ]
+        NSLayoutConstraint.activate(constraints)
     }
     
     func setTextField() {

--- a/ITZZA/ITZZA/Screen/Community/ImageAddBar.swift
+++ b/ITZZA/ITZZA/Screen/Community/ImageAddBar.swift
@@ -27,5 +27,14 @@ class ImageAddBar: UIView {
         guard let view = loadViewFromNib(with: Identifiers.imageAddBar) else { return }
         view.backgroundColor = .clear
         self.addSubview(view)
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = [
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ]
+        NSLayoutConstraint.activate(constraints)
     }
 }

--- a/ITZZA/ITZZA/Screen/Community/PostButtonsView.swift
+++ b/ITZZA/ITZZA/Screen/Community/PostButtonsView.swift
@@ -35,6 +35,15 @@ class PostButtonsView: UIView {
         guard let view = loadViewFromNib(with: Identifiers.postButtonsView) else { return }
         view.backgroundColor = .clear
         self.addSubview(view)
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = [
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ]
+        NSLayoutConstraint.activate(constraints)
     }
 }
 

--- a/ITZZA/ITZZA/Screen/Community/PostContentTableViewHeader.swift
+++ b/ITZZA/ITZZA/Screen/Community/PostContentTableViewHeader.swift
@@ -1,0 +1,86 @@
+//
+//  PostContentTableViewHeader.swift
+//  ITZZA
+//
+//  Created by 황윤경 on 2022/02/08.
+//
+
+import UIKit
+
+class PostContentTableViewHeader: UITableViewHeaderFooterView {
+    @IBOutlet weak var headerView: ProfileHeaderView!
+    @IBOutlet weak var footerView: PostButtonsView!
+    @IBOutlet weak var postContentView: PostContentView!
+    @IBOutlet weak var postButtonViewTopSpace: NSLayoutConstraint!
+    @IBOutlet weak var scrollView: UIScrollView!
+    var image:[UIImage] = []
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setContentView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setContentView()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+    }
+    
+    private func setContentView() {
+        guard let view = loadViewFromNib(with: Identifiers.postContentTableViewHeader) else { return }
+        self.addSubview(view)
+
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = [
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ]
+        NSLayoutConstraint.activate(constraints)
+        
+        view.addSubview(scrollView)
+    }
+    
+    func configurePost() {
+        scrollView.isScrollEnabled = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let imageViews = image.map { image -> UIImageView in
+            let imageView = UIImageView(image: image)
+            imageView.contentMode = .scaleAspectFit
+            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor).isActive = true
+            imageView.backgroundColor = .black
+            return imageView
+        }
+        
+        let stackView = UIStackView(arrangedSubviews: imageViews)
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = 20
+        scrollView.addSubview(stackView)
+
+        let constraints = [
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            
+            scrollView.heightAnchor.constraint(equalTo: stackView.heightAnchor)
+        ]
+        NSLayoutConstraint.activate(constraints)
+        
+        setPostButtonViewTopSpace()
+    }
+    
+    func setPostButtonViewTopSpace() {
+        if image.count == 0 {
+            postButtonViewTopSpace.constant = 0
+        }
+    }
+}

--- a/ITZZA/ITZZA/Screen/Community/PostContentTableViewHeader.xib
+++ b/ITZZA/ITZZA/Screen/Community/PostContentTableViewHeader.xib
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PostContentTableViewHeader" customModule="ITZZA" customModuleProvider="target">
+            <connections>
+                <outlet property="footerView" destination="JKx-gu-efv" id="uCv-OE-5uE"/>
+                <outlet property="headerView" destination="Gjo-Vc-ECo" id="0M0-QH-ghY"/>
+                <outlet property="postButtonViewTopSpace" destination="dxj-mI-p6W" id="4k4-W4-lzd"/>
+                <outlet property="postContentView" destination="lzN-7r-pD8" id="fXx-FJ-dIp"/>
+                <outlet property="scrollView" destination="rHl-RZ-2mq" id="xsd-Eh-JBi"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gjo-Vc-ECo" customClass="ProfileHeaderView" customModule="ITZZA" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="51"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="51" id="Xz1-Q2-eDX"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JKx-gu-efv" customClass="PostButtonsView" customModule="ITZZA" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="679" width="375" height="50"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="xIK-3I-ii1"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lzN-7r-pD8" customClass="PostContentView" customModule="ITZZA" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="51" width="375" height="102"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rHl-RZ-2mq">
+                    <rect key="frame" x="25" y="153" width="325" height="526"/>
+                    <viewLayoutGuide key="contentLayoutGuide" id="LPB-Lg-zMy"/>
+                    <viewLayoutGuide key="frameLayoutGuide" id="gen-Ux-T8S"/>
+                </scrollView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="lzN-7r-pD8" firstAttribute="top" secondItem="Gjo-Vc-ECo" secondAttribute="bottom" id="CUa-hK-lgy"/>
+                <constraint firstAttribute="trailing" secondItem="JKx-gu-efv" secondAttribute="trailing" id="EjU-TJ-uKs"/>
+                <constraint firstItem="lzN-7r-pD8" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="LWA-8J-Azl"/>
+                <constraint firstItem="rHl-RZ-2mq" firstAttribute="top" secondItem="lzN-7r-pD8" secondAttribute="bottom" id="Nv0-A9-SyF"/>
+                <constraint firstItem="Gjo-Vc-ECo" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="OZC-fr-O6V"/>
+                <constraint firstItem="rHl-RZ-2mq" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="25" id="R9E-l6-fqx"/>
+                <constraint firstAttribute="trailing" secondItem="Gjo-Vc-ECo" secondAttribute="trailing" id="Xzg-ad-Fhy"/>
+                <constraint firstItem="Gjo-Vc-ECo" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="b63-Q5-VVA"/>
+                <constraint firstItem="JKx-gu-efv" firstAttribute="top" secondItem="rHl-RZ-2mq" secondAttribute="bottom" constant="35" id="dxj-mI-p6W"/>
+                <constraint firstAttribute="bottom" secondItem="JKx-gu-efv" secondAttribute="bottom" id="iAw-Zl-ipJ"/>
+                <constraint firstAttribute="trailing" secondItem="rHl-RZ-2mq" secondAttribute="trailing" constant="25" id="jGM-7E-iQP"/>
+                <constraint firstItem="JKx-gu-efv" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="yf8-Cj-pcv"/>
+                <constraint firstAttribute="trailing" secondItem="lzN-7r-pD8" secondAttribute="trailing" id="zM3-n8-LKJ"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="132" y="99.384236453201979"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ITZZA/ITZZA/Screen/Community/PostContentView.swift
+++ b/ITZZA/ITZZA/Screen/Community/PostContentView.swift
@@ -9,29 +9,32 @@ import UIKit
 
 class PostContentView: UIView {
     @IBOutlet weak var postTitle: UILabel!
-    @IBOutlet weak var postContent: UITextView!
+    @IBOutlet weak var postContent: UILabel!
     
     override init(frame: CGRect) {
       super.init(frame: frame)
         setContentView()
-        setContents()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setContentView()
-        setContents()
     }
     
     private func setContentView() {
         guard let view = loadViewFromNib(with: Identifiers.postContentView) else { return }
         view.backgroundColor = .clear
         self.addSubview(view)
-    }
-    
-    func setContents() {
-        postContent.isScrollEnabled = false
-        postContent.isUserInteractionEnabled = false
-        postContent.backgroundColor = .clear
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = [
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ]
+        NSLayoutConstraint.activate(constraints)
+        
+        postContent.setLineBreakMode()
     }
 }

--- a/ITZZA/ITZZA/Screen/Community/PostContentView.xib
+++ b/ITZZA/ITZZA/Screen/Community/PostContentView.xib
@@ -18,7 +18,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PostContentView" customModule="ITZZA" customModuleProvider="target">
             <connections>
-                <outlet property="postContent" destination="MEE-OQ-ViI" id="F27-Lz-b1E"/>
+                <outlet property="postContent" destination="Itv-q2-N3h" id="fcg-8O-35n"/>
                 <outlet property="postTitle" destination="gLA-yl-A6C" id="uHS-Kf-xpp"/>
             </connections>
         </placeholder>
@@ -29,28 +29,29 @@
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLA-yl-A6C">
                     <rect key="frame" x="25" y="10" width="37.5" height="18"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="18" id="BUy-ZY-A7N"/>
+                    </constraints>
                     <fontDescription key="fontDescription" name="SFProDisplay-Bold" family="SF Pro Display" pointSize="15"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="MEE-OQ-ViI">
-                    <rect key="frame" x="20" y="36" width="335" height="56"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                    <color key="textColor" systemColor="labelColor"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Itv-q2-N3h">
+                    <rect key="frame" x="25" y="36" width="325" height="46"/>
                     <fontDescription key="fontDescription" name="SFProDisplay-Regular" family="SF Pro Display" pointSize="15"/>
-                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                </textView>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="MEE-OQ-ViI" firstAttribute="top" secondItem="gLA-yl-A6C" secondAttribute="bottom" constant="8" symbolic="YES" id="541-jF-izG"/>
                 <constraint firstItem="gLA-yl-A6C" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="5Mf-G5-vBj"/>
                 <constraint firstItem="gLA-yl-A6C" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="25" id="Gtq-dL-E5U"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="MEE-OQ-ViI" secondAttribute="bottom" constant="10" id="UAS-Mp-m31"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="MEE-OQ-ViI" secondAttribute="trailing" constant="20" id="qPg-E0-Hqr"/>
-                <constraint firstItem="MEE-OQ-ViI" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="zUO-pI-tnm"/>
+                <constraint firstItem="Itv-q2-N3h" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="25" id="Rfp-fE-g7i"/>
+                <constraint firstItem="Itv-q2-N3h" firstAttribute="top" secondItem="gLA-yl-A6C" secondAttribute="bottom" constant="8" symbolic="YES" id="T1L-WJ-qnp"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Itv-q2-N3h" secondAttribute="trailing" constant="25" id="blU-DC-1WD"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="Itv-q2-N3h" secondAttribute="bottom" constant="20" id="dON-Gj-LzC"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
@@ -59,9 +60,6 @@
         </view>
     </objects>
     <resources>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/ITZZA/ITZZA/Screen/Community/ProfileHeaderView.swift
+++ b/ITZZA/ITZZA/Screen/Community/ProfileHeaderView.swift
@@ -26,5 +26,14 @@ class ProfileHeaderView: UIView {
         guard let view = loadViewFromNib(with: Identifiers.profileHeaderView) else { return }
         view.backgroundColor = .clear
         self.addSubview(view)
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        let constraints = [
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ]
+        NSLayoutConstraint.activate(constraints)
     }
 }

--- a/ITZZA/ITZZA/Screen/Community/View/Controller/CategoryVC.swift
+++ b/ITZZA/ITZZA/Screen/Community/View/Controller/CategoryVC.swift
@@ -48,6 +48,7 @@ class CategoryVC: UIViewController {
 //MARK: - Custom Methods
 extension CategoryVC {
     func setPostTV() {
+        postListTV.delegate = self
         postListTV.backgroundColor = .systemGray6
         postListTV.separatorStyle = .none
         
@@ -83,5 +84,11 @@ extension CategoryVC {
         Observable.just(sections)
           .bind(to: postListTV.rx.items(dataSource: dataSource))
           .disposed(by: bag)
+    }
+}
+
+extension CategoryVC: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
     }
 }

--- a/ITZZA/ITZZA/Screen/Community/View/Controller/PostDetailVC.swift
+++ b/ITZZA/ITZZA/Screen/Community/View/Controller/PostDetailVC.swift
@@ -10,51 +10,45 @@ import RxSwift
 import RxDataSources
 
 class PostDetailVC: UIViewController {
-    @IBOutlet weak var postContentView: PostContentView!
     @IBOutlet weak var commentListTV: UITableView!
-    @IBOutlet weak var profileHeaderView: ProfileHeaderView!
-    @IBOutlet weak var postButtonsView: PostButtonsView!
     
     let bag = DisposeBag()
+    
+    let images: [UIImage] = [
+        UIImage(named: "Emoji_Angry")!,
+        UIImage(named: "Emoji_Comfy")!,
+        UIImage(named: "Emoji_Confuse")!
+    ]
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setCommentListTV()
-    }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        sizeHeaderToFit(tableView: commentListTV)
     }
 }
 
 //MARK: - Custom Methods
 extension PostDetailVC {
     func setCommentListTV() {
+        commentListTV.delegate = self
         commentListTV.backgroundColor = .systemGray6
         commentListTV.separatorStyle = .none
-        commentListTV.register(UINib(nibName: Identifiers.commentTVC, bundle: nil), forCellReuseIdentifier: Identifiers.commentTVC)
         
+        register()
         bindTV()
         bindPostListTVItemSelected()
     }
     
-    func sizeHeaderToFit(tableView: UITableView) {
-        if let headerView = tableView.tableHeaderView {
-            let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
-            var frame = headerView.frame
-            frame.size.height = height
-            headerView.frame = frame
-            tableView.tableHeaderView = headerView
-            headerView.setNeedsLayout()
-            headerView.layoutIfNeeded()
-        }
+    func register(){
+        commentListTV.register(UINib(nibName: Identifiers.commentTVC, bundle: nil), forCellReuseIdentifier: Identifiers.commentTVC)
+        commentListTV.register(PostContentTableViewHeader.self, forHeaderFooterViewReuseIdentifier: Identifiers.postContentTableViewHeader)
     }
     
     func bindPostListTVItemSelected() {
         commentListTV.rx.itemSelected
             .subscribe(onNext: { [weak self] indexPath in
-                self?.commentListTV.deselectRow(at: indexPath, animated: true)
+                if indexPath.row != 0 {
+                    print(indexPath.row, "댓글 눌림")
+                }
             })
             .disposed(by: bag)
     }
@@ -72,6 +66,7 @@ extension PostDetailVC {
                 return cell
             } else {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: Identifiers.commentTVC, for: indexPath) as? CommentTVC else { return UITableViewCell() }
+                cell.selectionStyle = .none
                 return cell
             }
         }
@@ -89,5 +84,19 @@ extension PostDetailVC {
         Observable.just(sections)
             .bind(to: commentListTV.rx.items(dataSource: datasource))
             .disposed(by: bag)
+    }
+}
+
+extension PostDetailVC: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: Identifiers.postContentTableViewHeader) as? PostContentTableViewHeader else { return nil }
+        headerView.image = images
+        headerView.configurePost()
+        
+        return headerView
+    }
+    
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
     }
 }

--- a/ITZZA/ITZZA/Screen/Community/View/Storyboard/Category.storyboard
+++ b/ITZZA/ITZZA/Screen/Community/View/Storyboard/Category.storyboard
@@ -70,17 +70,17 @@
                                                 </view>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="Yqd-co-ev6" firstAttribute="leading" secondItem="ROE-hK-Gt1" secondAttribute="leading" id="7K0-AP-47e"/>
                                                 <constraint firstItem="W2H-W3-njc" firstAttribute="leading" secondItem="ROE-hK-Gt1" secondAttribute="leading" id="8vm-c0-cIX"/>
+                                                <constraint firstItem="Yqd-co-ev6" firstAttribute="leading" secondItem="ROE-hK-Gt1" secondAttribute="leading" id="KMr-MQ-ftA"/>
                                                 <constraint firstItem="W2H-W3-njc" firstAttribute="top" secondItem="wZr-wd-seU" secondAttribute="bottom" constant="8" symbolic="YES" id="OIe-2D-HrS"/>
                                                 <constraint firstAttribute="bottom" secondItem="W2H-W3-njc" secondAttribute="bottom" id="Tyh-87-pkD"/>
                                                 <constraint firstAttribute="trailing" secondItem="QXZ-Da-ELH" secondAttribute="trailing" id="UNQ-8T-ltM"/>
+                                                <constraint firstAttribute="trailing" secondItem="Yqd-co-ev6" secondAttribute="trailing" id="YSV-we-iPz"/>
                                                 <constraint firstItem="W2H-W3-njc" firstAttribute="top" secondItem="Yqd-co-ev6" secondAttribute="bottom" constant="44" id="ZP5-v1-xoh"/>
                                                 <constraint firstItem="QXZ-Da-ELH" firstAttribute="top" secondItem="ROE-hK-Gt1" secondAttribute="top" constant="3" id="d8j-v0-5CQ"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="wZr-wd-seU" secondAttribute="trailing" id="dlN-bY-peA"/>
                                                 <constraint firstAttribute="trailing" secondItem="W2H-W3-njc" secondAttribute="trailing" id="oWP-jn-pag"/>
                                                 <constraint firstItem="Yqd-co-ev6" firstAttribute="top" secondItem="QXZ-Da-ELH" secondAttribute="bottom" id="pNs-IZ-nH2"/>
-                                                <constraint firstAttribute="trailing" secondItem="Yqd-co-ev6" secondAttribute="trailing" id="tqY-DI-B7L"/>
                                                 <constraint firstItem="QXZ-Da-ELH" firstAttribute="leading" secondItem="ROE-hK-Gt1" secondAttribute="leading" id="ybi-yB-jbf"/>
                                             </constraints>
                                         </tableViewCellContentView>

--- a/ITZZA/ITZZA/Screen/Community/View/Storyboard/PostDetail.storyboard
+++ b/ITZZA/ITZZA/Screen/Community/View/Storyboard/PostDetail.storyboard
@@ -21,46 +21,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="MJB-XE-rp5">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="MJB-XE-rp5">
                                 <rect key="frame" x="0.0" y="44" width="375" height="669"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <view key="tableHeaderView" contentMode="scaleToFill" id="2Nc-Wx-f2f">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="203"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wre-vP-bYg" customClass="ProfileHeaderView" customModule="ITZZA" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="51"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="51" id="318-AY-Uy3"/>
-                                            </constraints>
-                                        </view>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WUd-tV-nvb" customClass="PostButtonsView" customModule="ITZZA" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="153" width="375" height="50"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="50" id="Jmu-Z3-d4c"/>
-                                            </constraints>
-                                        </view>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vLD-9o-eUx" customClass="PostContentView" customModule="ITZZA" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="51" width="375" height="102"/>
-                                        </view>
-                                    </subviews>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="WUd-tV-nvb" secondAttribute="bottom" id="0hF-N4-dYy"/>
-                                        <constraint firstItem="wre-vP-bYg" firstAttribute="leading" secondItem="2Nc-Wx-f2f" secondAttribute="leading" id="3je-Qs-ver"/>
-                                        <constraint firstItem="vLD-9o-eUx" firstAttribute="leading" secondItem="2Nc-Wx-f2f" secondAttribute="leading" id="910-lR-MaN"/>
-                                        <constraint firstItem="WUd-tV-nvb" firstAttribute="leading" secondItem="2Nc-Wx-f2f" secondAttribute="leading" id="9d9-Kr-LBf"/>
-                                        <constraint firstItem="wre-vP-bYg" firstAttribute="top" secondItem="2Nc-Wx-f2f" secondAttribute="top" id="UyK-K1-bUC"/>
-                                        <constraint firstItem="WUd-tV-nvb" firstAttribute="top" secondItem="vLD-9o-eUx" secondAttribute="bottom" id="f43-6u-sJg"/>
-                                        <constraint firstAttribute="trailing" secondItem="WUd-tV-nvb" secondAttribute="trailing" id="kVF-SA-2bn"/>
-                                        <constraint firstAttribute="trailing" secondItem="vLD-9o-eUx" secondAttribute="trailing" id="o7S-aD-iAx"/>
-                                        <constraint firstAttribute="trailing" secondItem="wre-vP-bYg" secondAttribute="trailing" id="qpp-xW-AF5"/>
-                                        <constraint firstItem="vLD-9o-eUx" firstAttribute="top" secondItem="wre-vP-bYg" secondAttribute="bottom" id="zJ9-UT-F0K"/>
-                                    </constraints>
-                                </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="CommentCountCell" rowHeight="70" id="fs5-el-khf" customClass="CommentCountTVC" customModule="ITZZA" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="247.66666603088379" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="49" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fs5-el-khf" id="CDd-ja-eov">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -110,9 +76,6 @@
                     </view>
                     <connections>
                         <outlet property="commentListTV" destination="MJB-XE-rp5" id="4Ch-B1-neW"/>
-                        <outlet property="postButtonsView" destination="WUd-tV-nvb" id="ob3-ea-NWc"/>
-                        <outlet property="postContentView" destination="vLD-9o-eUx" id="Ftb-ab-pFv"/>
-                        <outlet property="profileHeaderView" destination="wre-vP-bYg" id="g9U-yO-EM7"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
## PR
- 게시글 상세 뷰 구현
   - postTitle, postContent 담은 View 따로 생성
   - 이미지 존재 여부에 따라 이미지 스택 추가
   - 이미지는 항상 정방형, 자동으로 맞춰짐
- 텍스트 입력 뷰 구현
- 홈에서 해당 post를 누르면 화면 전환
- didTapButton 함수 PostListTVC -> PostButtonView로 이동
- UILabel extension: 자동 줄바꿈

## 변경사항
다른 커밋은 #16 여기에

## 스크린샷
<img src="https://user-images.githubusercontent.com/61379671/153234147-5de0d645-daab-461c-8689-f89876ec9952.png" width="300">

<img src="https://user-images.githubusercontent.com/61379671/153233848-5b57540f-eac4-4f22-9405-bc56d68e4018.png" width="300">

#### Linked Issue
close #14 
