### PR TITLE
[FIX]: userId 저장 오류 해결

### DIFF
--- a/ITZZA/ITZZA/Screen/Sign/ViewModel/SignInVM.swift
+++ b/ITZZA/ITZZA/Screen/Sign/ViewModel/SignInVM.swift
@@ -73,7 +73,7 @@ extension SignInVM {
         UserDefaults.standard.set(email, forKey: "email")
         KeychainWrapper.standard[.myPassword] = password
         KeychainWrapper.standard[.myToken] = token
-        KeychainWrapper.standard[.userId] = userId
+        KeychainWrapper.standard[.userId] = String(userId)
     }
     
     private func saveUserDataToSingleton(_ token: String, _ userId: Int) {

--- a/ITZZA/ITZZA/Support/AppDelegate.swift
+++ b/ITZZA/ITZZA/Support/AppDelegate.swift
@@ -15,13 +15,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var email: String?
     var password: String?
     var token: String?
+    var userId: String?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         guard let userEmail = UserDefaults.standard.string(forKey: "email"),
               let userPassword: String = KeychainWrapper.standard[.myPassword],
-              let userToken: String = KeychainWrapper.standard[.myToken]
-              else {
+              let userToken: String = KeychainWrapper.standard[.myToken],
+              let keychainUserId: String = KeychainWrapper.standard[.userId] else {
                   let signInVC = ViewControllerFactory.viewController(for: .signIn)
                   self.window = UIWindow(frame: UIScreen.main.bounds)
                   self.window?.rootViewController = signInVC
@@ -32,6 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         email = userEmail
         password = userPassword
         token = userToken
+        userId = keychainUserId
         
         let tabBarVC = ViewControllerFactory.viewController(for: .tabBar)
         self.window = UIWindow(frame: UIScreen.main.bounds)


### PR DESCRIPTION
## PR
서버에서 보내주는 userId date type과 keychain에 저장할 때 data type이 불일치하여 발생한
로그인 정보 저장 오류로 인해 자동 로그인 실패 해결

userId는 Keychain에 String으로 저장됨
필요시 Int형으로 casting 요망

## 변경사항

## 스크린샷

로그인 화면 동일

#### Linked Issue
close #48 
