### PR TITLE
[FEAT]: 일기 작성 뷰 이미지 추가 버튼 기능 구현

### DIFF
--- a/ITZZA/ITZZA.xcodeproj/project.pbxproj
+++ b/ITZZA/ITZZA.xcodeproj/project.pbxproj
@@ -82,11 +82,11 @@
 		238EC09F27AA88EC001CBB24 /* ImageAddBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238EC09D27AA88EC001CBB24 /* ImageAddBar.swift */; };
 		238EC0A027AA88EC001CBB24 /* ImageAddBar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 238EC09E27AA88EC001CBB24 /* ImageAddBar.xib */; };
 		23A56BDA27B3F8BA00959269 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A56BD927B3F8BA00959269 /* UILabel+.swift */; };
+		23AEE7B127C6481D00C79FF5 /* KeywordContentTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AEE7AF27C6481D00C79FF5 /* KeywordContentTVC.swift */; };
+		23AEE7B227C6481D00C79FF5 /* KeywordContentTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 23AEE7B027C6481D00C79FF5 /* KeywordContentTVC.xib */; };
 		23B4DEC727C74E1A0051ED87 /* ImagesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B4DEC627C74E1A0051ED87 /* ImagesModel.swift */; };
 		23B4DECE27C750B40051ED87 /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B4DECC27C750B40051ED87 /* AlertView.swift */; };
 		23B4DECF27C750B40051ED87 /* AlertView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 23B4DECD27C750B40051ED87 /* AlertView.xib */; };
-		23AEE7B127C6481D00C79FF5 /* KeywordContentTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AEE7AF27C6481D00C79FF5 /* KeywordContentTVC.swift */; };
-		23AEE7B227C6481D00C79FF5 /* KeywordContentTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 23AEE7B027C6481D00C79FF5 /* KeywordContentTVC.xib */; };
 		23B66EBC27B813A500FC477D /* CategoryBottomSheetVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B66EBB27B813A500FC477D /* CategoryBottomSheetVC.swift */; };
 		23BCDC2C27C211D300054334 /* Notification+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23BCDC2B27C211D300054334 /* Notification+Name.swift */; };
 		23D56B5027C607360000D3E5 /* TabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D56B4E27C607360000D3E5 /* TabView.swift */; };
@@ -136,6 +136,7 @@
 		6254618827B1530500184DA1 /* NicknameView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6254618727B1530500184DA1 /* NicknameView.xib */; };
 		62654E5D27C75A3600A48363 /* EmojiAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62654E5C27C75A3600A48363 /* EmojiAnimationView.swift */; };
 		62654E5F27C75A6A00A48363 /* EmojiAnimationView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 62654E5E27C75A6A00A48363 /* EmojiAnimationView.xib */; };
+		62654E6127C7825700A48363 /* WriteDiaryVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62654E6027C7825700A48363 /* WriteDiaryVM.swift */; };
 		6270D40127ACE590004FD7A9 /* SignUpVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6270D40027ACE590004FD7A9 /* SignUpVC.swift */; };
 		627E1A8F27AEAD7D005C1777 /* Array+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627E1A8E27AEAD7D005C1777 /* Array+.swift */; };
 		62A855E427B6AECD007BA12B /* NicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A855E327B6AECD007BA12B /* NicknameModel.swift */; };
@@ -232,11 +233,11 @@
 		238EC09D27AA88EC001CBB24 /* ImageAddBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAddBar.swift; sourceTree = "<group>"; };
 		238EC09E27AA88EC001CBB24 /* ImageAddBar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImageAddBar.xib; sourceTree = "<group>"; };
 		23A56BD927B3F8BA00959269 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
+		23AEE7AF27C6481D00C79FF5 /* KeywordContentTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordContentTVC.swift; sourceTree = "<group>"; };
+		23AEE7B027C6481D00C79FF5 /* KeywordContentTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = KeywordContentTVC.xib; sourceTree = "<group>"; };
 		23B4DEC627C74E1A0051ED87 /* ImagesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesModel.swift; sourceTree = "<group>"; };
 		23B4DECC27C750B40051ED87 /* AlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
 		23B4DECD27C750B40051ED87 /* AlertView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AlertView.xib; sourceTree = "<group>"; };
-		23AEE7AF27C6481D00C79FF5 /* KeywordContentTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordContentTVC.swift; sourceTree = "<group>"; };
-		23AEE7B027C6481D00C79FF5 /* KeywordContentTVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = KeywordContentTVC.xib; sourceTree = "<group>"; };
 		23B66EBB27B813A500FC477D /* CategoryBottomSheetVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryBottomSheetVC.swift; sourceTree = "<group>"; };
 		23BCDC2B27C211D300054334 /* Notification+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Name.swift"; sourceTree = "<group>"; };
 		23D56B4E27C607360000D3E5 /* TabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabView.swift; sourceTree = "<group>"; };
@@ -287,6 +288,7 @@
 		6254618727B1530500184DA1 /* NicknameView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NicknameView.xib; sourceTree = "<group>"; };
 		62654E5C27C75A3600A48363 /* EmojiAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiAnimationView.swift; sourceTree = "<group>"; };
 		62654E5E27C75A6A00A48363 /* EmojiAnimationView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EmojiAnimationView.xib; sourceTree = "<group>"; };
+		62654E6027C7825700A48363 /* WriteDiaryVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteDiaryVM.swift; sourceTree = "<group>"; };
 		6270D40027ACE590004FD7A9 /* SignUpVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpVC.swift; sourceTree = "<group>"; };
 		627E1A8E27AEAD7D005C1777 /* Array+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+.swift"; sourceTree = "<group>"; };
 		62A855E327B6AECD007BA12B /* NicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameModel.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 			isa = PBXGroup;
 			children = (
 				232CC03927A0327B00040131 /* HomeVM.swift */,
+				62654E6027C7825700A48363 /* WriteDiaryVM.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1169,6 +1172,7 @@
 				623DE31127B65B27005E78D0 /* NicknameVM.swift in Sources */,
 				23A56BDA27B3F8BA00959269 /* UILabel+.swift in Sources */,
 				2368021127B2965B00A4392B /* PostContentTableViewHeader.swift in Sources */,
+				62654E6127C7825700A48363 /* WriteDiaryVM.swift in Sources */,
 				2323030927B035ED00E20078 /* UITextField+.swift in Sources */,
 				622D51CB27BEB54400F59679 /* HomeNC.swift in Sources */,
 				232CC07527A0370D00040131 /* TypeOfViewController.swift in Sources */,

--- a/ITZZA/ITZZA/Screen/Community/View/Storyboard/AddPost.storyboard
+++ b/ITZZA/ITZZA/Screen/Community/View/Storyboard/AddPost.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/ITZZA/ITZZA/Screen/Home/View/Controller/WriteDiaryVC.swift
+++ b/ITZZA/ITZZA/Screen/Home/View/Controller/WriteDiaryVC.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import RxSwift
 import RxCocoa
+import BSImagePicker
 
 class WriteDiaryVC: UIViewController {
     
@@ -22,13 +23,16 @@ class WriteDiaryVC: UIViewController {
     let emotionView = EmotionView()
     var postWriteView = PostWriteView()
     var scrollView = UIScrollView()
-    var imageScrollView = ImageScrollView()
     var emotionTextField = UITextField()
     var lineView = UIView()
     var stackView = UIStackView()
     var contentView = UIView()
     var imageAddBar = ImageAddBar()
     let textViewPlaceHolder = "오늘은 어떤 하루였나요?"
+    let writeDirayVM = WriteDiaryVM()
+    var imageListView = ImageCollectionView()
+    let maxImageSelectionCount = 3
+    let minimumLineSpacing: CGFloat = 20
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,6 +47,7 @@ class WriteDiaryVC: UIViewController {
         configureImageScrollView()
         configureImageAddBar()
         bindUI()
+        bindVM()
     }
 }
 
@@ -61,7 +66,7 @@ extension WriteDiaryVC {
         contentView.addSubview(emotionTextField)
         contentView.addSubview(lineView)
         contentView.addSubview(postWriteView)
-        contentView.addSubview(imageScrollView)
+        contentView.addSubview(imageListView)
         view.addSubview(imageAddBar)
     }
     
@@ -123,7 +128,7 @@ extension WriteDiaryVC {
             $0.top.equalTo(lineView.snp.bottom).offset(25)
             $0.leading.equalToSuperview()
             $0.trailing.equalToSuperview()
-            $0.bottom.equalTo(imageScrollView.snp.top).offset(-25)
+            $0.bottom.equalTo(imageListView.snp.top).offset(-25)
         }
         
         postWriteView.contents.delegate = self
@@ -132,7 +137,7 @@ extension WriteDiaryVC {
     }
     
     private func configureImageScrollView() {
-        imageScrollView.snp.makeConstraints {
+        imageListView.snp.makeConstraints {
             $0.top.equalTo(postWriteView.snp.bottom).offset(25)
             $0.leading.equalToSuperview()
             $0.trailing.equalToSuperview()
@@ -159,14 +164,62 @@ extension WriteDiaryVC {
                 self.dismiss(animated: true)
             })
             .disposed(by: disposeBag)
+        
+        imageAddBar.addImageButton.rx.tap
+            .asDriver()
+            .drive(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.pressedAddImageButton()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindVM() {
+        imageListView.numberOfImages
+            .asDriver(onErrorJustReturn: 0)
+            .drive(onNext: { [weak self] imageCount in
+                guard let self = self else { return }
+                self.setImageCVHeight(imageCount)
+            })
+            .disposed(by: disposeBag)
     }
 }
 
-// MARK: - Set Image
+// MARK: - Methods related to images
 extension WriteDiaryVC {
-    func addImagesToImageScrollView(with images: [UIImage]) {
-        imageScrollView.image = images
-        imageScrollView.configurePost()
+    func pressedAddImageButton() {
+        let imagePicker = ImagePickerController(selectedAssets: imageListView.selectedAssets)
+        
+        imagePicker.cancelButton.tintColor = .primary
+        imagePicker.doneButton.tintColor = .primary
+        imagePicker.settings.theme.selectionFillColor = .primary
+        
+        imagePicker.settings.selection.max = maxImageSelectionCount
+        imagePicker.settings.fetch.assets.supportedMediaTypes = [.image]
+        imagePicker.settings.theme.selectionStyle = .numbered
+        
+        self.presentImagePicker(imagePicker, select: { (asset) in
+        }, deselect: { (asset) in
+        }, cancel: { (assets) in
+        }, finish: { (assets) in
+            self.writeDirayVM.convertAssetToImages(assets, self.imageListView)
+            self.writeDirayVM.addImageToCollectionView(self.imageListView.selectedImages, self.imageListView)
+            self.setImageCVHeight(self.imageListView.selectedImages.count)
+            self.imageListView.selectedAssets = assets
+        }, completion: {
+        })
+    }
+    
+    func setImageCVHeight(_ imageCount: Int) {
+        if imageCount == 0 {
+            imageListView.snp.makeConstraints {
+                $0.height.equalTo(0)
+            }
+        } else {
+            imageListView.snp.makeConstraints {
+                $0.height.equalTo(CGFloat(imageCount) * (imageListView.imageCV.frame.width + minimumLineSpacing) - minimumLineSpacing)
+            }
+        }
     }
 }
 

--- a/ITZZA/ITZZA/Screen/Home/ViewModel/WriteDiaryVM.swift
+++ b/ITZZA/ITZZA/Screen/Home/ViewModel/WriteDiaryVM.swift
@@ -1,0 +1,48 @@
+//
+//  WriteDiaryVM.swift
+//  ITZZA
+//
+//  Created by InJe Choi on 2022/02/24.
+//
+
+import RxSwift
+import RxCocoa
+import Photos
+
+class WriteDiaryVM {
+    
+    var disposeBag = DisposeBag()
+    let minimumLineSpacing: CGFloat = 20
+    
+}
+
+// MARK: - Related to Adding Images
+extension WriteDiaryVM {
+    func addImageToCollectionView(_ images: [UIImage],
+                                  _ imageListView: ImageCollectionView) {
+        imageListView.selectedImages = images
+        imageListView.imageCV.reloadData()
+    }
+    
+    func convertAssetToImages(_ selectedAssets: [PHAsset],
+                              _ imageListView: ImageCollectionView) {
+        imageListView.selectedImages = selectedAssets.map {
+            let imageManager = PHImageManager.default()
+            let option = PHImageRequestOptions()
+            option.isSynchronous = true
+            var image = UIImage()
+            
+            imageManager.requestImage(for: $0,
+                                         targetSize: CGSize(width:300, height: 300),
+                                         contentMode: .aspectFit,
+                                         options: option) { (result, info) in
+                image = result!
+            }
+            
+            let data = image.jpegData(compressionQuality: 0.7)
+            let newImage = UIImage(data: data!)!
+            
+            return newImage
+        }
+    }
+}

--- a/ITZZA/ITZZA/Screen/Home/ViewModel/WriteDiaryVM.swift
+++ b/ITZZA/ITZZA/Screen/Home/ViewModel/WriteDiaryVM.swift
@@ -12,7 +12,6 @@ import Photos
 class WriteDiaryVM {
     
     var disposeBag = DisposeBag()
-    let minimumLineSpacing: CGFloat = 20
     
 }
 

--- a/ITZZA/ITZZA/Screen/Share/XibControllers/ImageCollectionView.swift
+++ b/ITZZA/ITZZA/Screen/Share/XibControllers/ImageCollectionView.swift
@@ -8,9 +8,13 @@
 import UIKit
 import Photos
 import SnapKit
+import RxSwift
+import RxCocoa
 
 class ImageCollectionView: UIView {
     @IBOutlet weak var imageCV: UICollectionView!
+    
+    let numberOfImages = PublishRelay<Int>()
     
     var selectedImages: [UIImage] = []
     var selectedAssets: [PHAsset] = []
@@ -72,6 +76,7 @@ extension ImageCollectionView: UICollectionViewDataSource {
 
         cell.deleteImageButton.addTarget(self, action: #selector(deleteCell(sender:)), for: .touchUpInside)
         
+        numberOfImages.accept(selectedImages.count)
         return cell
     }
 }


### PR DESCRIPTION
## PR
이미지 추가 버튼 클릭 시 앨범에서 이미지 고르기
고른 이미지 일기 작성 뷰 imageScrollView에 추가
이미지 삭제 시 CV 크기 축소 

## 변경사항

## 스크린샷

<img src = "https://user-images.githubusercontent.com/44153216/155566684-40bbe8c6-4089-422d-a738-dc6bc3c1f959.gif" width = 300 />


#### Linked Issue
close #57 
