### PR TITLE
[FEAT]: 작성한 일기 서버에 저장

### DIFF
--- a/ITZZA/ITZZA/Screen/Home/Model/HomeModel.swift
+++ b/ITZZA/ITZZA/Screen/Home/Model/HomeModel.swift
@@ -6,8 +6,9 @@
 //
 
 import UIKit
+import Alamofire
 
-struct HomeModel: Decodable {
+struct HomeModel: Codable {
     var dirayId: Int?
     var userId: Int?
     var date: String?
@@ -34,5 +35,17 @@ extension HomeModel {
         }
         
         return diaryImages
+    }
+}
+
+extension HomeModel {
+    var homeModelParam: Parameters {
+        return [
+            "date": date ?? "1970-01-01",
+            "categoryId": categoryId ?? 0,
+            "categoryReason": categoryReason ?? "Empty",
+            "diaryTitle": diaryTitle ?? "Empty",
+            "diaryContent": diaryContent ?? "Empty"
+        ]
     }
 }

--- a/ITZZA/ITZZA/Screen/Home/View/Controller/HomeVC.swift
+++ b/ITZZA/ITZZA/Screen/Home/View/Controller/HomeVC.swift
@@ -81,7 +81,7 @@ class HomeVC: UIViewController {
 
 // MARK: - Extra Functions
 extension HomeVC {
-    private func getFirstDiaryData() {
+    func getFirstDiaryData() {
         homeVM.getDiaryData(currentMonth, currentYear)
     }
     

--- a/ITZZA/ITZZA/Screen/Home/View/Shared/XibController/EmotionView.swift
+++ b/ITZZA/ITZZA/Screen/Home/View/Shared/XibController/EmotionView.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 enum GrayEmoji: String, CaseIterable {
     case angry = "GrayEmoji_Angry"

--- a/ITZZA/ITZZA/Screen/Home/ViewModel/HomeVM.swift
+++ b/ITZZA/ITZZA/Screen/Home/ViewModel/HomeVM.swift
@@ -70,6 +70,7 @@ class HomeVM {
             temporalView.postContentView.title.text = parsedData?.diaryTitle
             temporalView.postContentView.contents.text = parsedData?.diaryContent
             temporalView.addImagesToImageScrollView(with: parsedData?.diaryImages ?? [])
+            temporalView.addImagesToImageScrollView(with: [])
             
             temporalView.emotionSentence.textColor = .darkGray6
             temporalView.postContentView.title.textColor = .darkGray6

--- a/ITZZA/ITZZA/Screen/Home/ViewModel/WriteDiaryVM.swift
+++ b/ITZZA/ITZZA/Screen/Home/ViewModel/WriteDiaryVM.swift
@@ -12,6 +12,9 @@ import Photos
 class WriteDiaryVM {
     
     var disposeBag = DisposeBag()
+    let apiSession = APISession()
+    let postResponseError = PublishSubject<APIError>()
+    let postResponseSuccess = PublishSubject<HomeModel>()
     
 }
 
@@ -43,5 +46,45 @@ extension WriteDiaryVM {
             
             return newImage
         }
+    }
+}
+
+// MARK: - Networking
+extension WriteDiaryVM {
+    func postDiaryDataToServer(_ date: String,
+                               _ emotionView: EmotionView,
+                               _ postWriteView: PostWriteView,
+                               _ categoryReason: String,
+                               _ imageListView: ImageCollectionView) {
+        let baseURL = "http://13.125.239.189:3000/diaries"
+        let url = URL(string: baseURL)!
+        let resource = urlResource<HomeModel>(url: url)
+        let replacedDate = date.replacingOccurrences(of: ".", with: "-")
+        let categoryId = emotionView.selectedEmojiNumber ?? 0
+        let actualCategoryId: Int? = categoryId + 1
+        let diaryTitle = postWriteView.title.text
+        let diaryContent = postWriteView.contents.text
+        let diaryModel = HomeModel(date: replacedDate,
+                                   categoryId: actualCategoryId,
+                                   categoryReason: categoryReason,
+                                   diaryTitle: diaryTitle,
+                                   diaryContent: diaryContent)
+        let diaryParameter = diaryModel.homeModelParam
+        
+        apiSession.postRequestWithImages(with: resource,
+                                         param: diaryParameter,
+                                         images: imageListView.selectedImages,
+                                         method: .post)
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                switch result {
+                case .failure(let error):
+                    owner.postResponseError.onNext(error)
+                    
+                case .success(let response):
+                    owner.postResponseSuccess.onNext(response)
+                }
+            })
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## PR
작성한 일기 data 수집해서 서버로 전송
저장 성공 시 뷰 처리
저장 버튼 누르면 메인 화면으로 이동 및 캘린더 최신화

## 변경사항

## 스크린샷
(달력에 4월 15일을 유심히 봐주시면 됩니다.)

<img src = "https://user-images.githubusercontent.com/44153216/155707054-92cfc88f-cb6b-46dc-bc7a-488567266b6b.gif" width = 300 />

#### Linked Issue
close #59 
